### PR TITLE
feat: install graphite-cli

### DIFF
--- a/modules/common/ossareh.nix
+++ b/modules/common/ossareh.nix
@@ -35,6 +35,7 @@ in {
     dogdns
     duf
     dust
+    graphite-cli
     procs
     # inactive until https://github.com/LnL7/nix-darwin/pull/972 is merged
     # ollama


### PR DESCRIPTION
### TL;DR

Added Graphite CLI to the common tools list.

### What changed?

Added `graphite-cli` to the list of installed packages in `modules/common/ossareh.nix`. This adds the Graphite version control tool to the common toolset.

### How to test?

After applying this change, verify that the Graphite CLI is available by running:
```bash
gt --version
```

### Why make this change?

Graphite CLI provides improved Git workflows with features like stacked PRs and simplified code review. Adding it to the common tools makes this functionality available across environments.